### PR TITLE
MNT: Build with bleeding-edge fissa on binder

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - six=1.16.0=pyh6c4a22f_0
   - tbb=2021.3.0=h4bd325d_0
   - pip:
-    - fissa[plotting]
+    - git+https://github.com/rochefort-lab/fissa.git#egg=fissa[plotting]
     - future==0.18.2
     - imagecodecs==2020.2.18
     - imageio==2.8.0


### PR DESCRIPTION
We build with the master branch of the fissa repo instead of using the latest pip release. This means the latest version of the notebook can include features from the bleeding-edge version of fissa.