### PR TITLE
CI: Disable test cron-job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,9 +7,6 @@ name: tests
 on:
   push:
   pull_request:
-  schedule:
-    - cron:  "0 0 * * 1"
-      branches: [ $default-branch ]
 
 defaults:
   run:


### PR DESCRIPTION
It stops running after 60 days of inactivity, and then the tests don't run when something is actually pushed. Better to not have a cron job.